### PR TITLE
Set collision behavior to skip with force

### DIFF
--- a/Sitecore.Courier/FileCommandsFilter.cs
+++ b/Sitecore.Courier/FileCommandsFilter.cs
@@ -43,6 +43,10 @@ namespace Sitecore.Courier
       {
           command.CollisionBehavior = CollisionBehavior.Force;
       }
+      else
+      {
+          command.CollisionBehavior = CollisionBehavior.Skip;
+      }
 
       if (!(command is AddFolderCommand) && !(command is AddFileCommand))
       {


### PR DESCRIPTION
Currently when "ForceOverwrites" is set to false in the app.config, the
collision mode is left to the default value, which is also force, when the
package is then installed in "install" mode, which is always true for
Sitecore Ship:
https://github.com/kevinobee/Sitecore.Ship/blob/ebefe2c4bffbb5d0d3f77bc01c07395725c98487/src/Sitecore.Ship.Infrastructure/Update/UpdatePackageRunner.cs#L121

Setting it explicitly to skip, enables scenarios where Courier should
produce update packages containing only default values.
